### PR TITLE
add flash and ram usage to make output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,13 +249,12 @@ all: $(BUILD_DIR)/$(TARGET).elf $(BUILD_DIR)/$(TARGET).hex $(BUILD_DIR)/$(TARGET
 #######################################
 # helpers
 #######################################
-usedFlash = $(shell $(SZ) $@ | sed -n 2p | awk '{print $$1}' )
+usedFlash = $$( $(SZ) $@ | sed -n 2p | awk '{print $$1}' )
 usedFlashPercent = $$(( 100 * $(usedFlash) / $(FLASH_SIZE) ))
 flashMessage = Flash Used: $(usedFlash)/$(FLASH_SIZE) ( $(usedFlashPercent) % )
-usedRam = $(shell $(SZ) $@ | sed -n 2p | awk '{ram=$$2+$$3} {print ram}' )
+usedRam = $$( $(SZ) $@ | sed -n 2p | awk '{ram=$$2+$$3} {print ram}' )
 usedRamPercent = $$(( 100 * $(usedRam) / $(RAM_SIZE) ))
 ramMessage = Ram Used: $(usedRam)/$(RAM_SIZE) ( $(usedRamPercent) % ) - (static only)
-cyan = echo -e "\033[1;36m$(1)\033[0m"
 
 #######################################
 # build the application
@@ -283,7 +282,10 @@ $(BUILD_DIR)/%.o: %.s Makefile | $(BUILD_DIR)
 $(BUILD_DIR)/$(TARGET).elf: $(OBJECTS) Makefile
 	$(CC) $(OBJECTS) $(LDFLAGS) -o $@
 	$(SZ) $@
-	@$(call cyan,\n$(flashMessage)\n$(ramMessage)\n)
+	@echo ""
+	@echo "$(flashMessage)"
+	@echo "$(ramMessage)"
+	@echo ""
 
 $(BUILD_DIR)/%.hex: $(BUILD_DIR)/%.elf | $(BUILD_DIR)
 	$(HEX) $< $@


### PR DESCRIPTION
Closes #15 

When I was adding flash usage I noticed your firmware doesn't use much of the available flash but the ram usage is sitting pretty high so I added that too.  Probably want to keep an eye on it as well as see if there's anything easy you can do to pull it down out of the danger zone

![image](https://user-images.githubusercontent.com/21013281/150481216-bc175eb2-5e95-47d1-886f-c4502cb36639.png)

New make output:
```
...

arm-none-eabi-size build/ok-dev-board.elf
   text    data     bss     dec     hex filename
  40956      52  103320  144328   233c8 build/ok-dev-board.elf

Flash Used: 40956/524288  ( 7 % )
Ram Used: 103372/131072  ( 78 % ) - (static only)

arm-none-eabi-objcopy -O ihex build/ok-dev-board.elf build/ok-dev-board.hex
arm-none-eabi-objcopy -O binary -S build/ok-dev-board.elf build/ok-dev-board.bin
```